### PR TITLE
엔티티 equals() 버그 수정

### DIFF
--- a/src/main/java/com/example/projectboard/api/AritlcleCommend/entity/ArticleComment.java
+++ b/src/main/java/com/example/projectboard/api/AritlcleCommend/entity/ArticleComment.java
@@ -50,9 +50,9 @@ public class ArticleComment extends AuditingFields {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof ArticleComment)) return false;
+        if (!(o instanceof ArticleComment )) return false;
         ArticleComment that = (ArticleComment) o;
-        return id != null && id.equals(that.id);
+        return id != null && id.equals(that.getId());
     }
 
     @Override

--- a/src/main/java/com/example/projectboard/api/AritlcleCommend/entity/ArticleComment.java
+++ b/src/main/java/com/example/projectboard/api/AritlcleCommend/entity/ArticleComment.java
@@ -50,7 +50,7 @@ public class ArticleComment extends AuditingFields {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof ArticleComment )) return false;
+        if (!(o instanceof ArticleComment)) return false;
         ArticleComment that = (ArticleComment) o;
         return id != null && id.equals(that.getId());
     }

--- a/src/main/java/com/example/projectboard/api/Article/entity/Article.java
+++ b/src/main/java/com/example/projectboard/api/Article/entity/Article.java
@@ -64,8 +64,8 @@ public class Article extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof Article)) return false;
-        Article article = (Article) o;
-        return id != null && id.equals(article.id); // 새로만든 객체에 대해서는 다 다른 값으로 정의한다.
+        Article that = (Article) o;
+        return id != null && id.equals(that.getId()); // 새로만든 객체에 대해서는 다 다른 값으로 정의한다.
     }
 
     @Override

--- a/src/main/java/com/example/projectboard/api/User/entity/UserAccount.java
+++ b/src/main/java/com/example/projectboard/api/User/entity/UserAccount.java
@@ -54,8 +54,8 @@ public class UserAccount extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof UserAccount)) return false;
-        UserAccount userAccount = (UserAccount) o;
-        return userId != null && userId.equals(userAccount.userId);
+        UserAccount that = (UserAccount) o;
+        return userId != null && userId.equals(that.getUserId());
     }
 
     @Override


### PR DESCRIPTION
각 앤티티 클래스의 equals() 구현에 버그가 잇어서 수정하였다.

This closes #50 